### PR TITLE
Extract CachedKeyStorage protocol and improve CloudKit performance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-APIKeyReader is a Swift Package Manager library for iOS/macOS that manages API keys by fetching them from CloudKit and caching them locally. It uses modern Swift concurrency features and requires Swift 6.0+.
+APIKeyReader is a Swift Package Manager library for iOS/macOS that manages API keys by fetching them from CloudKit and caching them locally. It uses modern Swift concurrency features and requires Swift 6.2+.
 
 ## Development Commands
 
 ### Code Formatting
 ```bash
 ./formatcode.sh
-# Or manually: swiftformat . --indent 4 --swiftversion 6.0 --disable wrapMultilineStatementBraces
+# Or manually: swiftformat . --indent 4 --swiftversion 6.2 --disable wrapMultilineStatementBraces
 ```
 
 ### Building
@@ -64,6 +64,6 @@ The library defines specific error types:
 ## Important Notes
 
 - Always run `swiftformat` before committing changes
-- The library supports iOS 18+ and macOS 15+
+- The library supports iOS 26+ and macOS 26+
 - TestApp directory contains a sample implementation
 - All CloudKit operations are abstracted through the provider pattern

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ A Swift library for securely managing API keys using CloudKit, with intelligent 
 
 ## Requirements
 
-- iOS 18.0+
-- macOS 15.0+
-- Swift 6.0+
-- Xcode 16.0+
+- iOS 26.0+
+- macOS 26.0+
+- Swift 6.2+
+- Xcode 26.0+
 
 ## Installation
 

--- a/Sources/APIKeyReader/APIKeyReader.swift
+++ b/Sources/APIKeyReader/APIKeyReader.swift
@@ -27,6 +27,38 @@ protocol KeyProvider: Sendable {
 
 extension CloudKitKeyProvider: KeyProvider {}
 
+// MARK: - CachedKeyStorage
+
+/// A contract for storing and retrieving cached API keys.
+///
+/// Conforming types provide persistence for API keys with expiration-based invalidation,
+/// allowing ``APIKeyReader`` to avoid redundant CloudKit fetches.
+///
+/// - SeeAlso: ``LocalStorage`` for the Keychain-backed production implementation.
+/// - SeeAlso: ``APIKeyReader`` which uses this protocol to cache fetched keys.
+/// - SeeAlso: ``LoadError`` for errors thrown by ``load()``.
+protocol CachedKeyStorage: Sendable {
+    /// Loads the cached API key.
+    ///
+    /// - Returns: The cached API key if it exists and has not expired.
+    /// - Throws: ``LoadError/keyDoesNotExist`` if no cached key is found,
+    ///   ``LoadError/expired(_:)`` if the key exists but has expired,
+    ///   or ``LoadError/decodeError`` if the stored data is corrupted.
+    func load() throws -> APIKey
+
+    /// Removes the cached key from storage.
+    func clear()
+
+    /// Saves an API key to the cache with the given expiration.
+    ///
+    /// Passing `nil` for `value` clears the cached entry.
+    ///
+    /// - Parameters:
+    ///   - value: The API key to cache, or `nil` to clear.
+    ///   - expiresMinutes: Number of minutes until the cached key expires.
+    func save(value: APIKey?, expiresMinutes: Int)
+}
+
 // MARK: - APIKeyReader
 
 /// An actor that manages API keys by fetching them from CloudKit and caching them locally.
@@ -63,13 +95,19 @@ public actor APIKeyReader: Observable {
 
     let log = Log.logger
     private let keyProvider: any KeyProvider
+    private let localStorageFactory: @Sendable (APIKeyName) -> any CachedKeyStorage
 
     public init(containerIdentifier: String) {
         keyProvider = CloudKitKeyProvider(containerIdentifier: containerIdentifier)
+        localStorageFactory = { LocalStorage(key: $0) }
     }
 
-    init(keyProvider: any KeyProvider) {
+    init(
+        keyProvider: any KeyProvider,
+        localStorageFactory: @escaping @Sendable (APIKeyName) -> any CachedKeyStorage = { LocalStorage(key: $0) },
+    ) {
         self.keyProvider = keyProvider
+        self.localStorageFactory = localStorageFactory
     }
 
     /// Stores the fetch state for key fetches to prevent duplicate requests
@@ -81,7 +119,7 @@ public actor APIKeyReader: Observable {
     ///
     /// - Parameter apiKeyName: The name of the API key to clear
     public func clearCache(for apiKeyName: APIKeyName) {
-        LocalStorage(key: apiKeyName).clear()
+        localStorageFactory(apiKeyName).clear()
     }
 
     /// Retrieves an API key by name, with caching and automatic CloudKit fetching.
@@ -127,22 +165,24 @@ public actor APIKeyReader: Observable {
         // We can fallback to this if we have errors loading from CloudKit
         let expiredKey: APIKey?
 
-        let localStorage = LocalStorage(key: apiKeyName)
+        let localStorage = localStorageFactory(apiKeyName)
 
         do {
             return try localStorage.load()
-        } catch LoadError.decodeError {
-            expiredKey = nil
-            localStorage.clear()
-        } catch let LoadError.expired(key) {
-            logger.debug("key is expired")
-            expiredKey = key
-        } catch LoadError.keyDoesNotExist {
-            expiredKey = nil
+        } catch let loadError as LoadError {
+            switch loadError {
+            case .decodeError:
+                expiredKey = nil
+                localStorage.clear()
+            case let .expired(key):
+                logger.debug("key is expired")
+                expiredKey = key
+            case .keyDoesNotExist:
+                expiredKey = nil
+            }
         } catch {
-            expiredKey = nil
-            assertionFailure("Unknown error")
-            logger.error("Unhandled error")
+            log.error("Unexpected local storage error: \(String(describing: error), privacy: .public)")
+            throw error
         }
 
         log.debug("Key not found or expired in defaults for: \(apiKeyName)")

--- a/Sources/APIKeyReader/Contains/CloudKitKeyProvider/CloudKitKeyProvider.swift
+++ b/Sources/APIKeyReader/Contains/CloudKitKeyProvider/CloudKitKeyProvider.swift
@@ -9,16 +9,18 @@ private enum KeyField: String {
     /// API key value
     case key
 
+    static let log = os.Logger(subsystem: "com.spearware.foundation", category: "☁️CloudKit")
+
     /**
      Extract the value of the key from a CKRecord
      - parameter record: The CKRecord to extract from
      - throws FetchKeyError.missingField: If the key can isn't found or the expected type
      */
     func extract(from record: CKRecord) throws -> APIKey {
-        let log = os.Logger(subsystem: "com.spearware.foundation", category: "☁️CloudKit")
+        let log = Self.log
         let fieldName = rawValue
         if let value = record[fieldName] as? String {
-            log.debug("Field named: \(fieldName) found value of: \(value)")
+            log.debug("Field named: \(fieldName) found")
             return .init(rawValue: value)
         }
         log.error("Record was found, but not the field: \(fieldName)")
@@ -29,10 +31,10 @@ private enum KeyField: String {
 struct CloudKitKeyProvider: Sendable {
     private let log = os.Logger(subsystem: "com.spearware.foundation", category: "☁️CloudKit")
     private let recordType = "Keys"
-    private let containerIdentifier: String
+    private let container: CKContainer
 
     init(containerIdentifier: String) {
-        self.containerIdentifier = containerIdentifier
+        self.container = CKContainer(identifier: containerIdentifier)
     }
 
     // MARK: - APIKeyCloudKitType
@@ -104,6 +106,6 @@ struct CloudKitKeyProvider: Sendable {
     }
 
     private var database: CKDatabase {
-        CKContainer(identifier: containerIdentifier).publicCloudDatabase
+        container.publicCloudDatabase
     }
 }

--- a/Sources/APIKeyReader/Contains/CloudKitKeyProvider/Contains/FetchKeyError.swift
+++ b/Sources/APIKeyReader/Contains/CloudKitKeyProvider/Contains/FetchKeyError.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  An error was encountered when fetching a new Key
  **/
-enum FetchKeyError: LocalizedError {
+public enum FetchKeyError: LocalizedError {
     /// Attempt to read a field from CloudKit. The field was missing or an unexpected type
     case missingField(named: String)
     /// Error from CloudKit when attempting to retrieve record
@@ -13,7 +13,7 @@ enum FetchKeyError: LocalizedError {
     /// Airplane mode or poor network
     case networkUnavailable
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case let .missingField(fieldName):
             "[Developer Error] Invalid key configuration - missing \(fieldName)"

--- a/Sources/APIKeyReader/Contains/LocalStorage/LocalStorage.swift
+++ b/Sources/APIKeyReader/Contains/LocalStorage/LocalStorage.swift
@@ -3,7 +3,7 @@ import Security
 
 private let logger = Log.logger
 
-struct LocalStorage {
+struct LocalStorage: CachedKeyStorage {
     private let key: APIKeyName
 
     init(key: APIKeyName) {

--- a/Tests/APIKeyReaderTests/APIKeyReaderTests.swift
+++ b/Tests/APIKeyReaderTests/APIKeyReaderTests.swift
@@ -37,37 +37,107 @@ actor CountingDelayedKeyProvider: KeyProvider {
     }
 }
 
+// MARK: - Test Helpers
+
+enum LoadBehavior {
+    case value(APIKey)
+    case error(any Error)
+}
+
+final class TestStorageState: @unchecked Sendable {
+    var loadBehavior: LoadBehavior
+    var clearCallCount = 0
+    var saveCallCount = 0
+    var lastSavedKey: APIKey?
+
+    init(loadBehavior: LoadBehavior) {
+        self.loadBehavior = loadBehavior
+    }
+}
+
+struct TestCachedKeyStorage: CachedKeyStorage, @unchecked Sendable {
+    let state: TestStorageState
+
+    func load() throws -> APIKey {
+        switch state.loadBehavior {
+        case let .value(key):
+            return key
+        case let .error(error):
+            throw error
+        }
+    }
+
+    func clear() {
+        state.clearCallCount += 1
+        state.loadBehavior = .error(LoadError.keyDoesNotExist)
+    }
+
+    func save(value: APIKey?, expiresMinutes _: Int) {
+        state.saveCallCount += 1
+        state.lastSavedKey = value
+    }
+}
+
+private func reader(
+    provider: any KeyProvider,
+    state: TestStorageState,
+) -> APIKeyReader {
+    APIKeyReader(
+        keyProvider: provider,
+        localStorageFactory: { _ in
+            TestCachedKeyStorage(state: state)
+        },
+    )
+}
+
+private func isNetworkUnavailable(_ error: any Error) -> Bool {
+    guard let fetchError = error as? FetchKeyError else { return false }
+    if case .networkUnavailable = fetchError { return true }
+    return false
+}
+
 // MARK: - APIKeyReader Tests
 
 @Suite("APIKeyReader")
 struct APIKeyReaderTests {
     @Test("fetches from provider when cache is empty")
     func fetchesWhenCacheEmpty() async throws {
+        // Given: no cached key exists and provider returns a fresh key.
         let keyName = APIKeyName(rawValue: "api-key-reader.tests.\(UUID().uuidString)")
         let expectedKey = APIKey(rawValue: "fresh-\(UUID().uuidString)")
+        let storageState = TestStorageState(loadBehavior: .error(LoadError.keyDoesNotExist))
 
         let provider = SucceedingKeyProvider(apiKey: expectedKey)
-        let reader = APIKeyReader(keyProvider: provider)
+        let reader = reader(provider: provider, state: storageState)
 
+        // When: requesting the key through APIKeyReader.
         let result = try await reader.apiKey(named: keyName, expiresMinutes: 60)
+
+        // Then: the fetched provider key is returned.
         #expect(result.rawValue == expectedKey.rawValue)
+        #expect(storageState.saveCallCount == 1)
+        #expect(storageState.lastSavedKey?.rawValue == expectedKey.rawValue)
     }
 
     @Test("coalesces concurrent fetches for same key")
     func coalescesConcurrentFetchesForSameKey() async throws {
+        // Given: a delayed provider and two concurrent reads for the same key.
         let keyName = APIKeyName(rawValue: "api-key-reader.tests.\(UUID().uuidString)")
         let expectedKey = APIKey(rawValue: "coalesced-\(UUID().uuidString)")
+        let storageState = TestStorageState(loadBehavior: .error(LoadError.keyDoesNotExist))
 
         let provider = CountingDelayedKeyProvider(
             apiKey: expectedKey,
             delay: .milliseconds(100),
         )
-        let reader = APIKeyReader(keyProvider: provider)
+        let reader = reader(provider: provider, state: storageState)
 
+        // When: both requests are started before the first one completes.
         async let first = reader.apiKey(named: keyName, expiresMinutes: 60)
         async let second = reader.apiKey(named: keyName, expiresMinutes: 60)
         let (firstKey, secondKey) = try await (first, second)
 
+        // Then: both calls return the same value and only one provider fetch occurs.
         #expect(firstKey.rawValue == expectedKey.rawValue)
         #expect(secondKey.rawValue == expectedKey.rawValue)
         #expect(await provider.fetchCount == 1)
@@ -75,11 +145,14 @@ struct APIKeyReaderTests {
 
     @Test("throws when provider fails and no cached key exists")
     func throwsWhenNoFallback() async {
+        // Given: provider fails and no cached key exists.
         let keyName = APIKeyName(rawValue: "api-key-reader.tests.\(UUID().uuidString)")
+        let storageState = TestStorageState(loadBehavior: .error(LoadError.keyDoesNotExist))
 
         let provider = FailingKeyProvider(error: FetchKeyError.networkUnavailable)
-        let reader = APIKeyReader(keyProvider: provider)
+        let reader = reader(provider: provider, state: storageState)
 
+        // When/Then: requesting the key surfaces networkUnavailable.
         await #expect {
             try await reader.apiKey(named: keyName, expiresMinutes: 60)
         } throws: { error in
@@ -88,4 +161,76 @@ struct APIKeyReaderTests {
             return false
         }
     }
+
+    @Test("returns expired cached key when provider fails")
+    func returnsExpiredCachedKeyWhenProviderFails() async throws {
+        // Given: cache load reports an expired key and provider fails.
+        let keyName = APIKeyName(rawValue: "api-key-reader.tests.\(UUID().uuidString)")
+        let expiredKey = APIKey(rawValue: "expired-\(UUID().uuidString)")
+        let storageState = TestStorageState(loadBehavior: .error(LoadError.expired(expiredKey)))
+
+        let provider = FailingKeyProvider(error: FetchKeyError.networkUnavailable)
+        let reader = reader(provider: provider, state: storageState)
+
+        // When: requesting the key and CloudKit fetch fails.
+        let result = try await reader.apiKey(named: keyName, expiresMinutes: 60)
+
+        // Then: APIKeyReader falls back to the expired cached key.
+        #expect(result.rawValue == expiredKey.rawValue)
+    }
+
+    @Test("clears corrupt cached key when decode fails")
+    func clearsCorruptCachedKeyWhenDecodeFails() async {
+        // Given: cache load reports decode failure and provider fails.
+        let keyName = APIKeyName(rawValue: "api-key-reader.tests.\(UUID().uuidString)")
+        let storageState = TestStorageState(loadBehavior: .error(LoadError.decodeError))
+
+        let provider = FailingKeyProvider(error: FetchKeyError.networkUnavailable)
+        let reader = reader(provider: provider, state: storageState)
+
+        // When: requesting the key triggers decode failure and cache clear.
+        await #expect {
+            try await reader.apiKey(named: keyName, expiresMinutes: 60)
+        } throws: { error in
+            isNetworkUnavailable(error)
+        }
+
+        // Then: malformed cached value has been removed from local storage.
+        #expect(storageState.clearCallCount == 1)
+    }
+
+    @Test("rethrows unexpected storage errors")
+    func rethrowsUnexpectedStorageErrors() async {
+        // Given: cache load throws a non-LoadError and provider would succeed.
+        let keyName = APIKeyName(rawValue: "api-key-reader.tests.\(UUID().uuidString)")
+        let unexpectedError = NSError(domain: "test", code: 42)
+        let storageState = TestStorageState(loadBehavior: .error(unexpectedError))
+
+        let provider = SucceedingKeyProvider(apiKey: APIKey(rawValue: "unused"))
+        let reader = reader(provider: provider, state: storageState)
+
+        // When/Then: the unexpected error propagates without being swallowed.
+        await #expect {
+            try await reader.apiKey(named: keyName, expiresMinutes: 60)
+        } throws: { error in
+            (error as NSError).domain == "test" && (error as NSError).code == 42
+        }
+    }
+
+    @Test("clearCache removes cached key")
+    func clearCacheRemovesCachedKey() async {
+        // Given: a reader with a test storage backend.
+        let keyName = APIKeyName(rawValue: "api-key-reader.tests.\(UUID().uuidString)")
+        let storageState = TestStorageState(loadBehavior: .error(LoadError.keyDoesNotExist))
+
+        let provider = SucceedingKeyProvider(apiKey: APIKey(rawValue: "unused"))
+        let reader = reader(provider: provider, state: storageState)
+
+        // When: clearing the cache for a key.
+        await reader.clearCache(for: keyName)
+
+        // Then: clear was invoked on the storage.
+        #expect(storageState.clearCallCount == 1)
+    }
+
 }


### PR DESCRIPTION
## Summary

- Extract `CachedKeyStorage` protocol with factory injection, making `APIKeyReader` fully testable without hitting Keychain
- Cache `CKContainer` as a stored property to avoid repeated allocation on every database access
- Move `os.Logger` to a static property in `KeyField` to avoid per-call instantiation
- Remove accidental logging of API key values from CloudKit extraction
- Make `FetchKeyError` public so consumers can pattern-match on specific error cases
- Fix error handling: rethrow unexpected storage errors instead of silently swallowing them
- Add 4 new tests (expired key fallback, decode error clearing, clearCache, unexpected error propagation) — 7 total
- Update CLAUDE.md and README.md for Swift 6.2+ / iOS 26+ / macOS 26+

## Test plan

- [x] All 7 unit tests pass (`swift test`)
- [x] Periphery reports no unused code
- [x] DocC builds with no warnings
- [ ] Verify CloudKit key fetch works in TestApp on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)